### PR TITLE
SLING-11114 update SLING API to 2.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.16.4</version>
+            <version>2.21.0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION

(as indicated in https://github.com/apache/sling-org-apache-sling-caconfig-impl/pull/5)